### PR TITLE
Add static marketing site served by API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ cd ../client
 npm install
 ```
 
-### 2. Start the API server
+### 2. Start the API server and marketing site
 
 ```bash
 cd server
 npm start
 ```
 
-The API will boot on [http://localhost:4000](http://localhost:4000).
+The API and static marketing site will boot on [http://localhost:4000](http://localhost:4000). Open that URL in your browser to explore a live preview of the Heartville experience powered by the same demo data that the mobile client consumes.
 
 ### 3. Start the Expo client
 

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Heartville – Intentional Dating</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Epilogue:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="hero__nav">
+        <span class="logo">Heartville</span>
+        <a class="cta" href="#download">Get the app</a>
+      </nav>
+      <div class="hero__content">
+        <div class="hero__copy">
+          <h1>Dating that feels grounded, intentional, and delightfully human.</h1>
+          <p>
+            Heartville pairs handcrafted profiles with real-time insights so you can focus on sparking the right conversations.
+          </p>
+          <div class="hero__actions">
+            <a class="button button--primary" href="#demo">See the live demo</a>
+            <a class="button" href="#features">Explore features</a>
+          </div>
+        </div>
+        <div class="hero__card" id="hero-card"></div>
+      </div>
+    </header>
+
+    <main>
+      <section id="features" class="section">
+        <div class="section__heading">
+          <h2>Why people love Heartville</h2>
+          <p>Every interaction is designed to help you show up as your favorite version of yourself.</p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature">
+            <h3>Curated discovery</h3>
+            <p>
+              Scroll through richly designed profile cards that highlight the nuance behind every match—including vibe, compatibility, and prompts that actually inspire conversation.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Match momentum</h3>
+            <p>
+              Stay on top of new sparks with real-time toasts, conversation starters, and compatibility scores tailored to your shared interests.
+            </p>
+          </article>
+          <article class="feature">
+            <h3>Actionable insights</h3>
+            <p>
+              Weekly highlights summarize who responded, which prompts performed best, and ways to nurture your newest connections.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="demo" class="section section--accent">
+        <div class="section__heading">
+          <h2>Peek inside the experience</h2>
+          <p>
+            The page below pulls real demo data from the Heartville API so you can see the tone, storytelling, and compatibility framework in action.
+          </p>
+        </div>
+        <div class="demo" id="demo-profiles">
+          <div class="demo__loading" id="demo-loading">Loading profiles…</div>
+        </div>
+      </section>
+
+      <section id="download" class="section">
+        <div class="cta-card">
+          <div>
+            <h2>Ready to test Heartville with your team?</h2>
+            <p>
+              Spin up the Expo client for the full mobile experience and pair it with the server running this site. The instructions below will get you there in minutes.
+            </p>
+          </div>
+          <a class="button button--primary" href="https://expo.dev/" target="_blank" rel="noopener">Launch Expo</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>Made with intentionality in Austin, Denver, and Seattle.</p>
+    </footer>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/server/public/script.js
+++ b/server/public/script.js
@@ -1,0 +1,73 @@
+const heroCard = document.getElementById('hero-card');
+const demoContainer = document.getElementById('demo-profiles');
+const loadingState = document.getElementById('demo-loading');
+
+const renderHeroProfile = (profile) => {
+  if (!profile) return;
+  heroCard.innerHTML = `
+    <div class="hero-card__header">
+      <img class="hero-card__avatar" src="${profile.image}" alt="${profile.name}" />
+      <div>
+        <h3 class="hero-card__name">${profile.name}</h3>
+        <p class="hero-card__meta">${profile.age} • ${profile.location}</p>
+        <span class="hero-card__pill">${profile.compatibility}% compatibility</span>
+      </div>
+    </div>
+    <p class="hero-card__bio">${profile.bio}</p>
+  `;
+};
+
+const renderProfileCard = (profile) => {
+  const [firstPrompt] = profile.prompts ?? [];
+  return `
+    <article class="demo-card">
+      <div class="demo-card__header">
+        <img class="demo-card__avatar" src="${profile.image}" alt="${profile.name}" />
+        <div>
+          <h3 class="demo-card__name">${profile.name}</h3>
+          <p class="demo-card__meta">${profile.age} • ${profile.location}</p>
+          <p class="demo-card__meta">Vibe: ${profile.vibe}</p>
+        </div>
+      </div>
+      <div class="demo-card__prompt">
+        <h4>${firstPrompt?.question ?? 'Signature prompt'}</h4>
+        <p>${firstPrompt?.answer ?? 'A thoughtful spark awaits inside the mobile app.'}</p>
+      </div>
+      <p class="demo-card__insight">${profile.compatibilityWhy}</p>
+    </article>
+  `;
+};
+
+async function bootstrap() {
+  try {
+    const response = await fetch('/api/profiles');
+    if (!response.ok) {
+      throw new Error('Failed to load profiles');
+    }
+    const data = await response.json();
+    const profiles = data?.profiles ?? [];
+
+    if (profiles.length > 0) {
+      renderHeroProfile(profiles[1]);
+      const cards = profiles
+        .filter((profile) => profile.id !== 'user-1')
+        .slice(0, 3)
+        .map(renderProfileCard)
+        .join('');
+      demoContainer.innerHTML = cards;
+    } else {
+      demoContainer.innerHTML = '<p class="demo__loading">No profiles available just yet.</p>';
+    }
+  } catch (error) {
+    console.error(error);
+    demoContainer.innerHTML = `
+      <div class="demo__loading">
+        We hit a snag loading the demo content. Confirm the API server is running and refresh the page.
+      </div>
+    `;
+  } finally {
+    loadingState?.remove();
+  }
+}
+
+bootstrap();

--- a/server/public/styles.css
+++ b/server/public/styles.css
@@ -1,0 +1,327 @@
+:root {
+  --bg: #0f1014;
+  --bg-accent: #141721;
+  --bg-soft: #1c1f2b;
+  --text: #eef1ff;
+  --muted: #a8acc7;
+  --primary: #ff6b9a;
+  --primary-dark: #ff477e;
+  --card: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.1);
+  --shadow: 0 30px 80px rgba(15, 16, 20, 0.45);
+  font-family: 'Epilogue', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #1f2240 0%, var(--bg) 60%);
+}
+
+.hero {
+  padding: 3.5rem clamp(1.5rem, 4vw, 4rem) 4rem;
+}
+
+.hero__nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 3rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.cta {
+  color: var(--text);
+  text-decoration: none;
+  border: 1px solid var(--border);
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.cta:hover {
+  border-color: var(--primary);
+  transform: translateY(-2px);
+}
+
+.hero__content {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero__copy h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin: 0 0 1.5rem;
+  line-height: 1.1;
+}
+
+.hero__copy p {
+  margin: 0 0 2rem;
+  color: var(--muted);
+  max-width: 32rem;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.button:hover {
+  border-color: var(--text);
+  transform: translateY(-2px);
+}
+
+.button--primary {
+  background: linear-gradient(120deg, var(--primary), #ff9ec4);
+  color: #10122b;
+  border: none;
+}
+
+.button--primary:hover {
+  transform: translateY(-2px) scale(1.01);
+}
+
+.hero__card {
+  background: var(--card);
+  border-radius: 28px;
+  border: 1px solid var(--border);
+  min-height: 360px;
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.hero__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 107, 154, 0.35), transparent 60%);
+}
+
+.hero-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-card__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+
+.hero-card__name {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.hero-card__meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero-card__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 107, 154, 0.15);
+  color: #ffd3e4;
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin-bottom: 0.8rem;
+}
+
+.hero-card__bio {
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.section {
+  padding: 4.5rem clamp(1.5rem, 4vw, 4rem);
+}
+
+.section--accent {
+  background: linear-gradient(180deg, rgba(20, 23, 33, 0.4), rgba(15, 16, 20, 0.92));
+}
+
+.section__heading {
+  max-width: 40rem;
+  margin-bottom: 3rem;
+}
+
+.section__heading h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.section__heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature {
+  padding: 2rem;
+  background: var(--bg-soft);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: 0 15px 35px rgba(15, 16, 20, 0.25);
+}
+
+.feature h3 {
+  margin: 0 0 0.8rem;
+}
+
+.feature p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.demo {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.demo-card {
+  background: var(--bg-soft);
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 40px rgba(15, 16, 20, 0.35);
+}
+
+.demo-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.demo-card__avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 24px;
+  object-fit: cover;
+}
+
+.demo-card__name {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.demo-card__meta {
+  margin: 0;
+  color: var(--muted);
+}
+
+.demo-card__prompt {
+  background: rgba(255, 107, 154, 0.1);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 107, 154, 0.2);
+}
+
+.demo-card__prompt h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 219, 234, 0.85);
+}
+
+.demo-card__prompt p {
+  margin: 0;
+  color: var(--text);
+}
+
+.demo-card__insight {
+  color: var(--muted);
+  margin: 0;
+}
+
+.demo__loading {
+  color: var(--muted);
+}
+
+.cta-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: linear-gradient(130deg, rgba(255, 107, 154, 0.2), rgba(103, 157, 255, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: clamp(2rem, 3vw, 3rem);
+  align-items: flex-start;
+  box-shadow: var(--shadow);
+}
+
+.footer {
+  padding: 2rem;
+  text-align: center;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding-top: 2.5rem;
+  }
+
+  .hero__nav {
+    margin-bottom: 2rem;
+  }
+
+  .hero__actions {
+    width: 100%;
+  }
+
+  .hero__actions .button {
+    flex: 1 0 auto;
+    justify-content: center;
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,6 +3,8 @@ import cors from 'cors';
 import http from 'http';
 import { Server } from 'socket.io';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 dotenv.config();
 
@@ -20,12 +22,17 @@ const io = new Server(server, {
   },
 });
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const staticDir = path.join(__dirname, '../public');
+
 if (allowedOrigins) {
   app.use(cors({ origin: allowedOrigins }));
 } else {
   app.use(cors());
 }
 app.use(express.json());
+app.use(express.static(staticDir));
 
 const CURRENT_USER_ID = 'user-1';
 


### PR DESCRIPTION
## Summary
- add a static marketing experience under server/public that showcases Heartville and pulls demo data from the API
- serve the new static assets from Express so http://localhost:4000 renders the page alongside existing endpoints
- document that the API start command now also boots the marketing site

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d87be414e08332b01ef94639fdde54